### PR TITLE
Fix regression test following merge of my previous segos/voltas/repeats changes

### DIFF
--- a/TestFiles/NWCReallyCompleteExample.xml
+++ b/TestFiles/NWCReallyCompleteExample.xml
@@ -469,10 +469,6 @@
           <beats>3</beats>
           <beat-type>4</beat-type>
         </time>
-        <time>
-          <beats>6</beats>
-          <beat-type>8</beat-type>
-        </time>
         <key>
           <fifths>0</fifths>
           <mode>major</mode>
@@ -1504,14 +1500,6 @@
           <beats>4</beats>
           <beat-type>4</beat-type>
         </time>
-        <key>
-          <fifths>1</fifths>
-          <mode>major</mode>
-        </key>
-        <time>
-          <beats>4</beats>
-          <beat-type>4</beat-type>
-        </time>
         <staves>2</staves>
         <clef number="1">
           <sign>G</sign>
@@ -2015,10 +2003,6 @@
     <measure number="16">
       <attributes>
         <divisions>480</divisions>
-        <key>
-          <fifths>2</fifths>
-          <mode>major</mode>
-        </key>
         <key>
           <fifths>2</fifths>
           <mode>major</mode>

--- a/src/fr/lasconic/nwc2musicxml/convert/Nwc2MusicXML.java
+++ b/src/fr/lasconic/nwc2musicxml/convert/Nwc2MusicXML.java
@@ -815,7 +815,7 @@ public class Nwc2MusicXML implements IConstants {
 				// System.err.println( staff.measures.size() + ": " );
 				for (IElement e : measure.voices.get(voiceId)) {
 					if (e instanceof Wedge) {
-						System.err.println(((Wedge) e).type);
+						// System.err.println(((Wedge) e).type);
 					} else {
 						// System.err.println( "something" );
 					}


### PR DESCRIPTION
In my previous checked in code I fixed a problem whereby with a grand
stave, the key/time signatures were added twice (as Nwc2MusicXML
processed each stave in the NWC file, it added the key/time signatures
to the output, meaning on a grand stave you end up with both twcie).
Sibelius loads the output file, but MuseScore, with its more faithful
interpreation of MusicXML objects.  Although I fixed the problem in the
code, I appear not to have fixed the test.  I've now updated the
reference file, as the output is correct.
I've also commented out a System.err.println statement in the
Nwc2MusicXML.java file, which was a debugging line that had been left
uncommented (it prints every Wedge to System.err).